### PR TITLE
feat: create Math.hypot polyfill

### DIFF
--- a/src/utils/event.ts
+++ b/src/utils/event.ts
@@ -1,4 +1,5 @@
 import { Vector2, WebKitGestureEvent, DomEvents } from '../types'
+import { hypot } from './math'
 
 const WEBKIT_DISTANCE_SCALE_FACTOR = 260
 
@@ -71,7 +72,7 @@ export function getTwoTouchesEventValues(
 
   // const e: any = 'nativeEvent' in event ? event.nativeEvent : event
 
-  const distance = Math.hypot(dx, dy)
+  const distance = hypot(dx, dy)
   // FIXME rotation has inconsistant values so we're not using it atm
   // const angle = (e.rotation as number) ?? -(Math.atan2(dx, dy) * 180) / Math.PI
   const angle = -(Math.atan2(dx, dy) * 180) / Math.PI

--- a/src/utils/math.ts
+++ b/src/utils/math.ts
@@ -14,7 +14,7 @@ export function subV<T extends number[]>(v1: T, v2: T): T {
  * @returns distance
  */
 export function calculateDistance(movement: number[]): number {
-  return Math.hypot(...movement)
+  return hypot(...movement)
 }
 
 interface Kinematics {
@@ -66,4 +66,30 @@ export function calculateAllKinematics<T extends number[]>(movement: T, delta: T
 export function sign(x: number) {
   if (Math.sign) return Math.sign(x)
   return Number(x > 0) - Number(x < 0) || +x
+}
+
+/**
+ * Because IE doesn't support `Math.hypot` function, so we use the polyfill version of the function.
+ * This polyfill function is suggested by Mozilla:
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot#polyfill
+ * @param arg target number
+ */
+export function hypot(...args: number[]) {
+  let max = 0;
+  let sum = 0;
+  let containsInfinity = false;
+
+  for (let i = 0; i < args.length; ++i) {
+    var x = Math.abs(Number(args[i]));
+    if (x === Infinity)
+      containsInfinity = true
+    if (x > max) {
+      sum *= (max / x) * (max / x);
+      max = x;
+    }
+    sum += x === 0 && max === 0 ? 0 : (x / max) * (x / max);
+  }
+  return containsInfinity
+    ? Infinity
+    : (max === 1 / 0 ? 1 / 0 : max * Math.sqrt(sum));
 }


### PR DESCRIPTION
Because IE doesn't support `Math.hypot`, I defined polyfill function and applied it to all position where `Math.hypot` was used. It performs the same functionality.